### PR TITLE
Fix down migration order + add environment CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ Depending on your project's setup, it may make sense to write some custom grunt 
 - `pg-migrate down` - runs a single down migration.
 - `pg-migrate down {N}` - runs N down migrations from the current state.
 
+## Environment Flag
+
+Using your [dotenv](https://github.com/motdotla/dotenv) file, it's possible to setup multiple DB URLs to make migrating your production and test environments easier. Instead of just adding `DATABASE_URL` to your .env file, include also: `PROD_DB_URL` and/or `TEST_DB_URL` like:
+
+```
+DATABASE_URL="postgresql://dev_user:pass@localhost:5432/dev_database_name"
+TEST_DB_URL="postgresql://test_user:pass@localhost:5432/test_database_name"
+PROD_DB_URL="postgresql://prod_user:pass@prod.domain.com:5432/prod_database_name"
+```
+
+Then when you want to migrate those databases specifically, you can add the `-e` flag with a value of `prod` or `test` like:
+
+```
+pg-migrate up -e prod
+```
+
 ## Defining Migrations
 
 When you run `pg-migrate create` a new migration file is created that looks like this:

--- a/bin/pg-migrate
+++ b/bin/pg-migrate
@@ -72,12 +72,31 @@ if (global.dryRun) {
 }
 
 global.environment = argv.environment;
-if ( global.environment.substr(0, 4) == 'prod' && process.env.PROD_DB_URL ) {
-  var DATABASE_URL = process.env.PROD_DB_URL;
-} else if ( global.environment.substr(0, 4) == 'test' && process.env.TEST_DB_URL ) {
-  var DATABASE_URL = process.env.TEST_DB_URL;
-} else {
-  var DATABASE_URL = process.env.DATABASE_URL;
+switch ( global.environment ) {
+  case 'prod':
+    if ( typeof process.env.PROD_DB_URL === 'undefined' ) {
+      console.log('PROD_DB_URL not specified in your environment.');
+      process.exit(1);
+    }
+    DATABASE_URL = process.env.PROD_DB_URL;
+    break;
+
+  case 'test':
+    if ( typeof process.env.TEST_DB_URL === 'undefined' ) {
+      console.log('TEST_DB_URL not specified in your environment.');
+      process.exit(1);
+    }
+    DATABASE_URL = process.env.TEST_DB_URL;
+    break;
+
+  case 'dev':
+    var DATABASE_URL = process.env.DATABASE_URL;
+    break;
+
+  default:
+    console.log('Invalid --environment of "'+ global.environment +'" specified. Valid options are ["dev", "prod", "test"].');
+    process.exit(1);
+    break;
 }
 
 var MIGRATIONS_DIR = argv['migrations-dir'];

--- a/bin/pg-migrate
+++ b/bin/pg-migrate
@@ -34,7 +34,7 @@ var argv = optimist
     .alias('t', 'migrations-table')
     .string('t')
 
-    .describe('environment', 'The environment you want to migrate. If `prod`, uses PROD_DB_URL env variable.')
+    .describe('environment', 'The environment you want to migrate. If `prod`, uses PROD_DB_URL env variable. If `test`, uses TEST_DB_URL env variable.')
     .alias('e', 'environment')
     .string('e')
 
@@ -74,6 +74,8 @@ if (global.dryRun) {
 global.environment = argv.environment;
 if ( global.environment.substr(0, 4) == 'prod' && process.env.PROD_DB_URL ) {
   var DATABASE_URL = process.env.PROD_DB_URL;
+} else if ( global.environment.substr(0, 4) == 'test' && process.env.TEST_DB_URL ) {
+  var DATABASE_URL = process.env.TEST_DB_URL;
 } else {
   var DATABASE_URL = process.env.DATABASE_URL;
 }

--- a/bin/pg-migrate
+++ b/bin/pg-migrate
@@ -74,6 +74,7 @@ if (global.dryRun) {
 global.environment = argv.environment;
 switch ( global.environment ) {
   case 'prod':
+  case 'production':
     if ( typeof process.env.PROD_DB_URL === 'undefined' ) {
       console.log('PROD_DB_URL not specified in your environment.');
       process.exit(1);
@@ -90,6 +91,7 @@ switch ( global.environment ) {
     break;
 
   case 'dev':
+  case 'development':
     var DATABASE_URL = process.env.DATABASE_URL;
     break;
 

--- a/bin/pg-migrate
+++ b/bin/pg-migrate
@@ -19,7 +19,8 @@ process.on('uncaughtException', function(err) {
 var argv = optimist
     .default({
       verbose: false,
-      "force-exit": false,
+      'force-exit': false,
+      environment: 'dev',
       'migrations-dir': process.cwd() + '/migrations',
       'migrations-table': 'pgmigrations',
     })
@@ -32,6 +33,10 @@ var argv = optimist
     .describe('migrations-table', 'The table storing which migrations have been run (default = `pgmigrations`)')
     .alias('t', 'migrations-table')
     .string('t')
+
+    .describe('environment', 'The environment you want to migrate. If `prod`, uses PROD_DB_URL env variable.')
+    .alias('e', 'environment')
+    .string('e')
 
     .describe('dry-run', "Prints the SQL but doesn't run it.")
     .boolean('dry-run')
@@ -66,9 +71,14 @@ if (global.dryRun) {
   console.log('dry run');
 }
 
+global.environment = argv.environment;
+if ( global.environment.substr(0, 4) == 'prod' && process.env.PROD_DB_URL ) {
+  var DATABASE_URL = process.env.PROD_DB_URL;
+} else {
+  var DATABASE_URL = process.env.DATABASE_URL;
+}
 
 var MIGRATIONS_DIR = argv['migrations-dir'];
-var DATABASE_URL = process.env["DATABASE_URL"];
 var MIGRATIONS_TABLE = argv['migrations-table'];
 
 var action = argv._.shift();

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -69,7 +69,7 @@ module.exports = function MigrationRunner(options){
             if(options.direction == 'up') {
               to_run = runMigrations.slice(0, options.count);
             } else {
-              to_run = doneMigrations.slice(options.count * -1);
+              to_run = doneMigrations.slice(options.count * -1).reverse();
             }
           }
         }
@@ -138,5 +138,3 @@ module.exports = function MigrationRunner(options){
 
 
 }
-
-

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postgres",
     "postgresql"
   ],
-  "version": "0.0.10",
+  "version": "0.0.11",
   "engines": {
     "node": ">=0.6.0"
   },


### PR DESCRIPTION
I would have broken this up into multiple pull requests, but realized later that I fixed the down ordering a commit after I started adding in this new feature... but it's a super simple fix anyways (just need to add `.reverse()` to one line).

As for the new feature, I thought it would be nice to have a CLI flag to quickly switch between environments like production and testing. Would love to get this integrated and I'm happy to make any additional updates to get it pulled in :)